### PR TITLE
Feature/be/1/post

### DIFF
--- a/src/main/java/com/haribo/community_service/CommunityServiceApplication.java
+++ b/src/main/java/com/haribo/community_service/CommunityServiceApplication.java
@@ -1,0 +1,11 @@
+package com.haribo.community_service;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class CommunityServiceApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(CommunityServiceApplication.class, args);
+    }
+}

--- a/src/main/java/com/haribo/community_service/common/amazonS3/S3Service.java
+++ b/src/main/java/com/haribo/community_service/common/amazonS3/S3Service.java
@@ -1,0 +1,7 @@
+package com.haribo.community_service.common.amazonS3;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface S3Service {
+    String uploadFile(MultipartFile file);
+}

--- a/src/main/java/com/haribo/community_service/common/amazonS3/S3ServiceImpl.java
+++ b/src/main/java/com/haribo/community_service/common/amazonS3/S3ServiceImpl.java
@@ -1,0 +1,41 @@
+package com.haribo.community_service.common.amazonS3;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.haribo.community_service.common.exception.CustomErrorCode;
+import com.haribo.community_service.common.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class S3ServiceImpl implements S3Service {
+
+    private final AmazonS3 amazonS3;
+
+    @Value("${cloud.aws.s3.bucket-name}")
+    private String bucketName;
+
+    public String uploadFile(MultipartFile file) {
+
+        log.info("S3ServiceImpl의 uploadFile 메서드 실행 - file이 null이거나, file이 비어있으면 null 반환!");
+
+        if(file == null || file.isEmpty()) return null;
+
+        if(file.getSize() > 10485760) throw new CustomException(CustomErrorCode.FILE_SIZE_OVER_10MB);
+
+        String fileName = System.currentTimeMillis() + "_" + file.getOriginalFilename();
+        try {
+            amazonS3.putObject(new PutObjectRequest(bucketName, fileName, file.getInputStream(), null));
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to upload file", e);
+        }
+        return amazonS3.getUrl(bucketName, fileName).toString();
+    }
+}

--- a/src/main/java/com/haribo/community_service/common/config/AutoConfig.java
+++ b/src/main/java/com/haribo/community_service/common/config/AutoConfig.java
@@ -1,0 +1,37 @@
+package com.haribo.community_service.common.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class AutoConfig {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 amazonS3() {
+        BasicAWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+        return AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .build();
+    }
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/com/haribo/community_service/post/application/dto/Post.java
+++ b/src/main/java/com/haribo/community_service/post/application/dto/Post.java
@@ -1,0 +1,48 @@
+package com.haribo.community_service.post.application.dto;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Post {
+    @Id
+    @Setter
+    private String postId;
+
+    @NotBlank
+    @Column(name = "post_author_id")
+    private String postAuthorId;
+
+    @NotBlank
+    @Column(name = "post_type_id")
+    private String postType;
+
+    @NotBlank
+    private String postTitle;
+
+    @NotBlank
+    private String postContent;
+
+    private String postImageFile;
+
+    private LocalDateTime postCreatedDate;
+
+    @CreationTimestamp
+    private LocalDateTime postModifiedDate;
+
+    @Setter
+    private boolean deleteFlagPost;
+
+    @Setter
+    private long postNum;
+}

--- a/src/main/java/com/haribo/community_service/post/application/service/PostService.java
+++ b/src/main/java/com/haribo/community_service/post/application/service/PostService.java
@@ -1,0 +1,24 @@
+package com.haribo.community_service.post.application.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.haribo.community_service.post.presentation.request.PostRequestForCreate;
+import com.haribo.community_service.post.presentation.request.PostRequestForUpdate;
+import com.haribo.community_service.post.presentation.response.AllPostResponse;
+import com.haribo.community_service.post.presentation.response.PostMainResponse;
+import com.haribo.community_service.post.presentation.response.PostResponse;
+import org.apache.tomcat.util.json.ParseException;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+public interface PostService {
+
+    List<PostMainResponse> getTop5Posts();
+    List<AllPostResponse> getAllPosts();
+    PostResponse getPostById(String postId) throws ParseException;
+    PostResponse createPost(String profileId, PostRequestForCreate request, MultipartFile imageUrl) throws JsonProcessingException;
+    void updatePost(String profileId, PostRequestForUpdate request, MultipartFile imageUrl) throws JsonProcessingException;
+    void deletePost(String profileId, String postId) throws JsonProcessingException;
+    String generatePrimaryKey();
+    long generateOrderNum();
+}

--- a/src/main/java/com/haribo/community_service/post/application/service/PostServiceImpl.java
+++ b/src/main/java/com/haribo/community_service/post/application/service/PostServiceImpl.java
@@ -1,0 +1,189 @@
+package com.haribo.community_service.post.application.service;
+
+import com.haribo.community_service.comment.application.dto.Comment;
+import com.haribo.community_service.common.amazonS3.S3ServiceImpl;
+import com.haribo.community_service.post.application.dto.Post;
+
+import com.haribo.community_service.comment.domain.repository.CommentRepository;
+import com.haribo.community_service.post.domain.repository.PostRepository;
+import com.haribo.community_service.common.exception.CustomErrorCode;
+import com.haribo.community_service.common.exception.CustomException;
+import com.haribo.community_service.post.presentation.request.PostRequestForCreate;
+import com.haribo.community_service.post.presentation.request.PostRequestForUpdate;
+import com.haribo.community_service.post.presentation.response.AllPostResponse;
+import com.haribo.community_service.comment.presentation.response.CommentResponse;
+import com.haribo.community_service.post.presentation.response.PostMainResponse;
+import com.haribo.community_service.post.presentation.response.PostResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PostServiceImpl implements PostService {
+
+    private final PostRepository postRepository;
+    private final S3ServiceImpl s3Service;
+    private final CommentRepository commentRepository;
+
+    @Override
+    public List<PostMainResponse> getTop5Posts() {
+
+        List<Post> postList = postRepository.findTop5ByOrderBycreatedDatetDesc()
+                .orElseThrow(()->new CustomException(CustomErrorCode.POST_NOT_FOUND));
+
+        List<PostMainResponse> postMainResponseList = new ArrayList<>();
+
+        for (Post post : postList){
+            postMainResponseList.add(PostMainResponse.builder()
+                            .postId(post.getPostId())
+                            .postAuthorId(post.getPostAuthorId())
+                            .postTitle(post.getPostTitle())
+                            .postCreatedDate(post.getPostCreatedDate())
+                            .build());
+        }
+
+        return postMainResponseList;
+    }
+
+    @Override
+    public List<AllPostResponse> getAllPosts() {
+
+        log.info("모든 게시글 조회: 게시판 리스트!");
+
+        List<Post> posts = postRepository.findByDeleteFlagPostFalse();
+
+        return posts.stream()
+                .map(AllPostResponse::fromEntity)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public PostResponse getPostById(String postId) {
+
+        log.info("게시글 하나 조회하기!");
+
+        Post post = postRepository.findByPostIdAndDeleteFlagPostFalse(postId)
+                .orElseThrow(() -> new CustomException(CustomErrorCode.POST_NOT_FOUND));
+
+        List<Comment> comments = commentRepository.findByPostIdAndDeleteFlagCommentFalse(post.getPostId());
+        List<CommentResponse> commentResponseList = new ArrayList<>();
+
+        for (Comment comment : comments) {
+            CommentResponse commentResponse = CommentResponse.builder()
+                    .commentId(comment.getCommentId())
+                    .commentAuthorId(comment.getCommentAuthorId())
+                    .commentContent(comment.getCommentContent())
+                    .commentCreatedDate(comment.getCommentCreatedDate())
+                    .build();
+            commentResponseList.add(commentResponse);
+        }
+
+        return PostResponse.fromEntity(post, commentResponseList);
+    }
+
+    @Override
+    public PostResponse createPost(String profileId, PostRequestForCreate request, MultipartFile file) {
+
+        log.info("글 작성하기!");
+
+        String generatedId = generatePrimaryKey();
+
+        String imageUrl = Optional.ofNullable(s3Service.uploadFile(file)).orElse("");
+
+        Post post = Post.builder()
+                .postId(generatedId)
+                .postAuthorId(profileId)
+                .postType(request.getPostTypeId())
+                .postTitle(request.getPostTitle())
+                .postContent(request.getPostContent())
+                .postCreatedDate(LocalDateTime.now())
+                .postModifiedDate(LocalDateTime.now())
+                .postImageFile(imageUrl)
+                .deleteFlagPost(false)
+                .postNum(generateOrderNum())
+                .build();
+
+        postRepository.save(post);
+
+        if(postRepository.existsById(generatedId)) return PostResponse.fromEntity(post, new ArrayList<>());
+        else throw new CustomException(CustomErrorCode.POST_NOT_CREATED);
+    }
+
+    @Override
+    public void updatePost(String profileId, PostRequestForUpdate request, MultipartFile file) {
+
+        log.info("글 수정 하기!");
+
+        Post postBf = postRepository.findByPostIdAndDeleteFlagPostFalse(request.getPostId())
+                .orElseThrow(() -> new CustomException(CustomErrorCode.POST_NOT_FOUND));
+
+        String imageUrl = Optional.ofNullable(s3Service.uploadFile(file)).orElse(postBf.getPostImageFile());
+
+        if(postBf.getPostAuthorId().equals(profileId)) {
+            Post postAf = Post.builder()
+                    .postId(postBf.getPostId())
+                    .postAuthorId(profileId)
+                    .postType(request.getPostTypeId())
+                    .postTitle(request.getPostTitle())
+                    .postContent(request.getPostContent())
+                    .postImageFile(imageUrl)
+                    .postCreatedDate(postBf.getPostCreatedDate())
+                    .postModifiedDate(LocalDateTime.now())
+                    .deleteFlagPost(false)
+                    .postNum(postBf.getPostNum())
+                    .build();
+
+            postRepository.save(postAf);
+        } else throw new CustomException(CustomErrorCode.POST_NOT_UPDATED);
+    }
+
+    @Override
+    public void deletePost(String profileId, String postId) {
+
+        log.info("글 삭제하기!");
+
+        // id로 찾고, flag가 false인 것만 찾기
+        Post post = postRepository.findByPostIdAndDeleteFlagPostFalse(postId)
+                .orElseThrow(() -> new CustomException(CustomErrorCode.POST_NOT_FOUND));
+
+        if(post.getPostAuthorId().equals(profileId)) {
+            post.setDeleteFlagPost(true);
+            postRepository.save(post);
+
+            log.info("게시글과 연결되어 있던 코멘트 모두 삭제하기!");
+
+            List<Comment> commentListByPost = commentRepository.findByPostIdAndDeleteFlagCommentFalse(post.getPostId());
+
+            for (Comment comment : commentListByPost) {
+                comment.setDeleteFlagComment(true);
+                commentRepository.save(comment);
+            }
+        } else throw new CustomException(CustomErrorCode.DELETE_POST_FAILED);
+    }
+
+    @Override
+    public String generatePrimaryKey() {
+
+        log.info("pk 생성");
+
+        String prefix = "CP";
+        String uuid = UUID.randomUUID().toString();
+
+        return prefix + uuid;
+    }
+
+    @Override
+    public long generateOrderNum() {
+        return postRepository.count() + 1;
+    }
+}

--- a/src/main/java/com/haribo/community_service/post/domain/repository/PostRepository.java
+++ b/src/main/java/com/haribo/community_service/post/domain/repository/PostRepository.java
@@ -1,0 +1,16 @@
+package com.haribo.community_service.post.domain.repository;
+
+import com.haribo.community_service.post.application.dto.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface PostRepository extends JpaRepository<Post, String> {
+    List<Post> findByDeleteFlagPostFalse();
+    Optional<Post> findByPostIdAndDeleteFlagPostFalse(String postId);
+
+    @Query(value = "SELECT * FROM post WHERE delete_flag_post = FALSE ORDER BY post_created_date DESC LIMIT 5", nativeQuery = true)
+    Optional<List<Post>> findTop5ByOrderBycreatedDatetDesc();
+}

--- a/src/main/java/com/haribo/community_service/post/presentation/PostController.java
+++ b/src/main/java/com/haribo/community_service/post/presentation/PostController.java
@@ -1,0 +1,74 @@
+package com.haribo.community_service.post.presentation;
+
+import com.haribo.community_service.common.auth.AuthService;
+import com.haribo.community_service.post.application.service.PostServiceImpl;
+import com.haribo.community_service.post.presentation.request.PostRequestForCreate;
+import com.haribo.community_service.post.presentation.request.PostRequestForUpdate;
+import com.haribo.community_service.post.presentation.response.PostResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.net.URISyntaxException;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/community/post")
+public class PostController {
+
+    private final PostServiceImpl postServiceImpl;
+    private final AuthService authService;
+
+    @GetMapping("/main")
+    public ResponseEntity<?> getMainPosts() {
+
+        return ResponseEntity.status(HttpStatus.OK).body(postServiceImpl.getTop5Posts());
+    }
+
+    @GetMapping
+    public ResponseEntity<?> getAllPosts() {
+
+        return ResponseEntity.status(HttpStatus.OK).body(postServiceImpl.getAllPosts());
+    }
+
+    @GetMapping("/{postId}")
+    public ResponseEntity<PostResponse> getPostById(@PathVariable("postId") String postId) {
+
+        return ResponseEntity.status(HttpStatus.OK).body(postServiceImpl.getPostById(postId));
+    }
+
+    @PostMapping
+    public ResponseEntity<?> createPost(
+            @RequestPart PostRequestForCreate request,
+            @RequestPart(value = "file", required = false) MultipartFile file,
+            @CookieValue("JSESSIONID") String sessionId) throws URISyntaxException {
+
+        String profileId = authService.authorizedProfileId(sessionId);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(postServiceImpl.createPost(profileId, request, file));
+    }
+
+    @PatchMapping
+    public ResponseEntity<?> updatePost(
+            @RequestPart PostRequestForUpdate request,
+            @RequestPart(value = "file", required = false) MultipartFile file,
+            @CookieValue("JSESSIONID") String sessionId) throws URISyntaxException {
+
+        String profileId = authService.authorizedProfileId(sessionId);
+
+            postServiceImpl.updatePost(profileId, request, file);
+            return (ResponseEntity<?>) ResponseEntity.status(HttpStatus.NO_CONTENT);
+    }
+
+    @DeleteMapping
+    public ResponseEntity<?> deletePost(@RequestBody String postId,
+                                        @CookieValue("JSESSIONID") String sessionId) throws URISyntaxException {
+
+        String profileId = authService.authorizedProfileId(sessionId);
+
+        postServiceImpl.deletePost(profileId, postId);
+        return (ResponseEntity<?>) ResponseEntity.status(HttpStatus.NO_CONTENT);
+    }
+}

--- a/src/main/java/com/haribo/community_service/post/presentation/request/PostRequestForCreate.java
+++ b/src/main/java/com/haribo/community_service/post/presentation/request/PostRequestForCreate.java
@@ -1,0 +1,20 @@
+package com.haribo.community_service.post.presentation.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostRequestForCreate {
+    @NotBlank
+    private String postTypeId;
+
+    @NotBlank
+    private String postTitle;
+
+    @NotBlank
+    private String postContent;
+}

--- a/src/main/java/com/haribo/community_service/post/presentation/request/PostRequestForUpdate.java
+++ b/src/main/java/com/haribo/community_service/post/presentation/request/PostRequestForUpdate.java
@@ -1,0 +1,23 @@
+package com.haribo.community_service.post.presentation.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostRequestForUpdate {
+    @NotBlank
+    private String postId;
+
+    @NotBlank
+    private String postTypeId;
+
+    @NotBlank
+    private String postTitle;
+
+    @NotBlank
+    private String postContent;
+}

--- a/src/main/java/com/haribo/community_service/post/presentation/response/AllPostResponse.java
+++ b/src/main/java/com/haribo/community_service/post/presentation/response/AllPostResponse.java
@@ -1,0 +1,43 @@
+package com.haribo.community_service.post.presentation.response;
+
+import com.haribo.community_service.post.application.dto.Post;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class AllPostResponse {
+
+    @NotBlank
+    private String postId;
+
+    @NotBlank
+    private String postAuthorId;
+
+    @NotBlank
+    private long postNum;
+
+    @NotBlank
+    private String postTypeId;
+
+    @NotBlank
+    private String postTitle;
+
+    @NotBlank
+    private LocalDateTime postCreatedDate;
+
+    public static AllPostResponse fromEntity (Post post) {
+        return new AllPostResponse(
+                post.getPostId(),
+                post.getPostAuthorId(),
+                post.getPostNum(),
+                post.getPostType(),
+                post.getPostTitle(),
+                post.getPostCreatedDate());
+    }
+}

--- a/src/main/java/com/haribo/community_service/post/presentation/response/PostMainResponse.java
+++ b/src/main/java/com/haribo/community_service/post/presentation/response/PostMainResponse.java
@@ -1,0 +1,26 @@
+package com.haribo.community_service.post.presentation.response;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class PostMainResponse {
+
+    @NotBlank
+    String postId;
+
+    @NotBlank
+    String postTitle;
+
+    @NotBlank
+    String postAuthorId;
+
+    @NotBlank
+    LocalDateTime postCreatedDate;
+}

--- a/src/main/java/com/haribo/community_service/post/presentation/response/PostMainResponse.java
+++ b/src/main/java/com/haribo/community_service/post/presentation/response/PostMainResponse.java
@@ -3,10 +3,12 @@ package com.haribo.community_service.post.presentation.response;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
+@Getter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor

--- a/src/main/java/com/haribo/community_service/post/presentation/response/PostResponse.java
+++ b/src/main/java/com/haribo/community_service/post/presentation/response/PostResponse.java
@@ -1,0 +1,40 @@
+package com.haribo.community_service.post.presentation.response;
+
+import com.haribo.community_service.post.application.dto.Post;
+import com.haribo.community_service.comment.presentation.response.CommentResponse;
+import lombok.*;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class PostResponse implements Serializable {
+
+    private String postId;
+    private String postAuthorId;
+    private String postTypeId;
+    private String postTitle;
+    private String postContent;
+    private String postImageFile;
+    private LocalDateTime postCreatedDate;
+    private LocalDateTime postModifiedDate;
+
+    private List<CommentResponse> comments;
+
+    public static PostResponse fromEntity(Post post, List<CommentResponse> commentList) {
+        return new PostResponse(
+                post.getPostId(),
+                post.getPostAuthorId(),
+                post.getPostType(),
+                post.getPostTitle(),
+                post.getPostContent(),
+                post.getPostImageFile(),
+                post.getPostCreatedDate(),
+                post.getPostModifiedDate(),
+                commentList);
+    }
+}
+


### PR DESCRIPTION
## 🗂️ 이슈 연결
- #1 

</br>

## 📌 구현한 API
- 게시글 단일 조회 : `Get  /api/v1/post/{postId}`
- 게시글 전체 조회 : `Get  /api/v1/post`
- 게시글 최근 생성 5개 조회 : `Get  /api/v1/post/main`
- 게시글 작성 : `Post  /api/notice/post`
- 게시글 수정 : `Patch  /api/notice/post`
- 게시글 삭제 : `Delete  /api/notice/post`

</br>

## 📝 작업 사항
- 게시판 CRUD 진행
- 응답에 따라 상황별 responsedto 생성
- softdelete 이용해서 게시글 삭제 구현
- session에 저장되어 있는 정보를 auth 서버에 담아 요청해서 받은 profileId 값 사용하기

</br>