### PR TITLE
Feature/be/7/comment

### DIFF
--- a/src/main/java/com/haribo/community_service/comment/application/dto/Comment.java
+++ b/src/main/java/com/haribo/community_service/comment/application/dto/Comment.java
@@ -1,0 +1,39 @@
+package com.haribo.community_service.comment.application.dto;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Comment {
+    @Id
+    @Setter
+    private String commentId;
+
+    @NotBlank
+    private String postId;
+
+    @NotBlank
+    @Column(name = "comment_author_id")
+    private String commentAuthorId;
+
+    @NotBlank
+    private String commentContent;
+
+    private LocalDateTime commentCreatedDate;
+
+    @CreationTimestamp
+    private LocalDateTime commentModifiedDate;
+
+    @Setter
+    private boolean deleteFlagComment;
+}

--- a/src/main/java/com/haribo/community_service/comment/application/service/CommentService.java
+++ b/src/main/java/com/haribo/community_service/comment/application/service/CommentService.java
@@ -1,0 +1,18 @@
+package com.haribo.community_service.comment.application.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.haribo.community_service.comment.presentation.request.CommentRequestForCreate;
+import com.haribo.community_service.comment.presentation.request.CommentRequestForUpdate;
+import com.haribo.community_service.comment.presentation.response.CommentResponse;
+
+import java.net.URISyntaxException;
+import java.util.List;
+
+public interface CommentService {
+
+    List<CommentResponse> getCommentsByUserId(String profileId);
+    CommentResponse createComment(String profileId, CommentRequestForCreate request) throws URISyntaxException, JsonProcessingException;
+    void updateComment(String profileId, CommentRequestForUpdate request);
+    void deleteComment(String profileId, String commentId);
+    String generatePrimaryKey();
+}

--- a/src/main/java/com/haribo/community_service/comment/application/service/CommentServiceImpl.java
+++ b/src/main/java/com/haribo/community_service/comment/application/service/CommentServiceImpl.java
@@ -1,0 +1,139 @@
+package com.haribo.community_service.comment.application.service;
+
+import com.haribo.community_service.comment.application.dto.Comment;
+import com.haribo.community_service.comment.domain.repository.CommentRepository;
+import com.haribo.community_service.post.domain.repository.PostRepository;
+import com.haribo.community_service.common.exception.CustomErrorCode;
+import com.haribo.community_service.common.exception.CustomException;
+import com.haribo.community_service.comment.presentation.request.CommentRequestForCreate;
+import com.haribo.community_service.comment.presentation.request.CommentRequestForUpdate;
+
+import com.haribo.community_service.comment.presentation.response.CommentResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.URISyntaxException;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CommentServiceImpl implements CommentService {
+
+    private final CommentRepository commentRepository;
+    private final PostRepository postRepository;
+    private final RestTemplate restTemplate;
+
+    @Value("${path.to.noti}")
+    private String pathToNoti;
+
+    @Override
+    public List<CommentResponse> getCommentsByUserId(String profileId) {
+
+        log.info("유저별 작성한 게시글 조회하기!");
+
+        return commentRepository.findByCommentAuthorIdAndDeleteFlagCommentFalse(profileId).stream()
+                .map(CommentResponse::fromEntity)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public CommentResponse createComment(String profileId, CommentRequestForCreate request) throws URISyntaxException {
+
+        log.info("코멘트 생성하기!");
+
+        postRepository.findByPostIdAndDeleteFlagPostFalse(request.getPostId())
+                .orElseThrow(() -> new CustomException(CustomErrorCode.POST_NOT_FOUND));
+
+        String generatedId = generatePrimaryKey();
+
+        Comment comment = Comment.builder()
+                .commentId(generatedId)
+                .postId(request.getPostId())
+                .commentAuthorId(profileId)
+                .commentContent(request.getCommentContent())
+                .commentCreatedDate(LocalDateTime.now())
+                .commentModifiedDate(LocalDateTime.now())
+                .deleteFlagComment(false)
+                .build();
+
+        commentRepository.save(comment);
+
+        if(commentRepository.existsById(generatedId)) {
+
+            log.info("알람 처리 부분 주석 해놨어요..!");
+
+//            Post post = postRepository.findByPostIdAndDeleteFlagPostFalse(request.getPostId())
+//                    .orElseThrow(()-> new CustomException(CustomErrorCode.POST_NOT_FOUND));
+//
+//            HttpHeaders headers = new HttpHeaders();
+//            headers.setContentType(MediaType.APPLICATION_JSON);
+//            HttpEntity<CommentRequestForAlarm> requestEntity = new HttpEntity<>(CommentRequestForAlarm.builder()
+//                    .receiver(post.getPostAuthorId())
+//                    .add(post.getPostId())
+//                    .typeId("NT06")
+//                    .build(), headers);
+//
+//            ResponseEntity<String> alarmRes = restTemplate.exchange(new URI(pathToNoti), HttpMethod.POST, requestEntity, String.class);
+//            log.info("알람 서버 요청 성공: {}", requestEntity);
+
+            return CommentResponse.fromEntity(comment);
+        }
+        else throw new CustomException(CustomErrorCode.COMMENT_NOT_CREATED);
+    }
+
+    @Override
+    public void updateComment(String profileId, CommentRequestForUpdate request) {
+
+        log.info("코멘트 업데이트!");
+
+        Comment commentBf = commentRepository.findByCommentIdAndDeleteFlagCommentFalse(request.getCommentId())
+                .orElseThrow(() -> new CustomException(CustomErrorCode.COMMENT_NOT_FOUND));
+
+        if(profileId.equals(commentBf.getCommentAuthorId())) {
+            Comment commentAf = Comment.builder()
+                    .commentId(request.getCommentId())
+                    .postId(commentBf.getPostId())
+                    .commentAuthorId(profileId)
+                    .commentContent(request.getCommentContent())
+                    .commentCreatedDate(commentBf.getCommentCreatedDate())
+                    .commentModifiedDate(LocalDateTime.now())
+                    .deleteFlagComment(false)
+                    .build();
+
+            commentRepository.save(commentAf);
+        } else throw new CustomException(CustomErrorCode.COMMENT_NOT_UPDATED);
+    }
+
+    @Override
+    public void deleteComment(String profileId, String commentId) {
+
+        log.info("코멘트 삭제!");
+
+        Comment comment = commentRepository.findByCommentIdAndDeleteFlagCommentFalse(commentId)
+                .orElseThrow(() -> new CustomException(CustomErrorCode.COMMENT_NOT_FOUND));
+
+        if(profileId.equals(comment.getCommentAuthorId())) {
+            comment.setDeleteFlagComment(true);
+
+            commentRepository.save(comment);
+        } else throw new CustomException(CustomErrorCode.DELETE_COMMENT_FAILED);
+    }
+
+    @Override
+    public String generatePrimaryKey() {
+        
+        log.info("pk 생성");
+        
+        String prefix = "CC";
+        String uuid = UUID.randomUUID().toString();
+
+        return prefix + uuid;
+    }
+}

--- a/src/main/java/com/haribo/community_service/comment/domain/repository/CommentRepository.java
+++ b/src/main/java/com/haribo/community_service/comment/domain/repository/CommentRepository.java
@@ -1,0 +1,13 @@
+package com.haribo.community_service.comment.domain.repository;
+
+import com.haribo.community_service.comment.application.dto.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CommentRepository extends JpaRepository<Comment, String> {
+    List<Comment> findByCommentAuthorIdAndDeleteFlagCommentFalse(String userId);
+    List<Comment> findByPostIdAndDeleteFlagCommentFalse(String postId);
+    Optional<Comment> findByCommentIdAndDeleteFlagCommentFalse(String commentId);
+}

--- a/src/main/java/com/haribo/community_service/comment/presentation/CommentController.java
+++ b/src/main/java/com/haribo/community_service/comment/presentation/CommentController.java
@@ -1,0 +1,67 @@
+package com.haribo.community_service.comment.presentation;
+
+import com.haribo.community_service.comment.application.service.CommentServiceImpl;
+import com.haribo.community_service.comment.presentation.request.CommentRequestForCreate;
+import com.haribo.community_service.comment.presentation.request.CommentRequestForUpdate;
+import com.haribo.community_service.comment.presentation.response.CommentResponse;
+import com.haribo.community_service.common.auth.AuthService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URISyntaxException;
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/community/comment")
+public class CommentController {
+
+    private final CommentServiceImpl commentServiceImpl;
+    private final AuthService authService;
+
+    @GetMapping
+    public ResponseEntity<List<CommentResponse>> getCommentsByUserId(@CookieValue("JSESSIONID") String sessionId) throws URISyntaxException {
+
+        String profileId = authService.authorizedProfileId(sessionId);
+
+        return ResponseEntity.status(HttpStatus.OK).body(commentServiceImpl.getCommentsByUserId(profileId));
+    }
+
+    @PostMapping
+    public ResponseEntity<?> createComment(@CookieValue("JSESSIONID") String sessionId, @RequestBody CommentRequestForCreate request) throws URISyntaxException {
+
+        log.info("세션 스트링: {}", sessionId);
+
+        String profileId = authService.authorizedProfileId(sessionId);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(commentServiceImpl.createComment(profileId, request));
+    }
+
+    @PatchMapping
+    public ResponseEntity<?> updateComment(@CookieValue("JSESSIONID") String sessionId, @RequestBody CommentRequestForUpdate request) throws URISyntaxException {
+
+        log.info("세션 스트링: {}", sessionId);
+
+        String profileId = authService.authorizedProfileId(sessionId);
+
+        commentServiceImpl.updateComment(profileId, request);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
+    @DeleteMapping()
+    public ResponseEntity<?> deleteComment(@CookieValue("JSESSIONID") String sessionId, @RequestBody String commentId) throws URISyntaxException {
+
+        log.info("세션 스트링: {}", sessionId);
+
+        String profileId = authService.authorizedProfileId(sessionId);
+
+        commentServiceImpl.deleteComment(profileId, commentId);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
+
+}

--- a/src/main/java/com/haribo/community_service/comment/presentation/request/CommentRequestForAlarm.java
+++ b/src/main/java/com/haribo/community_service/comment/presentation/request/CommentRequestForAlarm.java
@@ -1,0 +1,19 @@
+package com.haribo.community_service.comment.presentation.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommentRequestForAlarm {
+
+    @NotBlank
+    private String receiver;
+
+    @NotBlank
+    private String add;
+
+    @NotBlank
+    private String typeId;
+}

--- a/src/main/java/com/haribo/community_service/comment/presentation/request/CommentRequestForCreate.java
+++ b/src/main/java/com/haribo/community_service/comment/presentation/request/CommentRequestForCreate.java
@@ -1,0 +1,18 @@
+package com.haribo.community_service.comment.presentation.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommentRequestForCreate {
+
+    @NotBlank
+    private String postId;
+
+    @NotBlank
+    private String commentContent;
+}

--- a/src/main/java/com/haribo/community_service/comment/presentation/request/CommentRequestForUpdate.java
+++ b/src/main/java/com/haribo/community_service/comment/presentation/request/CommentRequestForUpdate.java
@@ -1,0 +1,18 @@
+package com.haribo.community_service.comment.presentation.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommentRequestForUpdate {
+
+    @NotBlank
+    private String commentId;
+
+    @NotBlank
+    private String commentContent;
+}

--- a/src/main/java/com/haribo/community_service/comment/presentation/response/CommentResponse.java
+++ b/src/main/java/com/haribo/community_service/comment/presentation/response/CommentResponse.java
@@ -1,0 +1,35 @@
+package com.haribo.community_service.comment.presentation.response;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+import com.haribo.community_service.comment.application.dto.Comment;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class CommentResponse implements Serializable {
+
+    @NotBlank
+    private String commentId;
+
+    @NotBlank
+    private String commentAuthorId;
+
+    @NotBlank
+    private String commentContent;
+
+    @NotBlank
+    private LocalDateTime commentCreatedDate;
+
+    public static CommentResponse fromEntity(Comment comment) {
+        return new CommentResponse(
+                comment.getCommentId(),
+                comment.getCommentAuthorId(),
+                comment.getCommentContent(),
+                comment.getCommentCreatedDate()
+        );
+    }
+}


### PR DESCRIPTION
## 🗂️ 이슈 연결
- #7 
</br>

## 📌 구현한 API
- 댓글 user 별 조회 : `Get  /api/v1/community/comment`
- 댓글 작성 : `Post  /api/v1/community/comment`
- 댓글 수정 : `Patch  /api/v1/community/comment`
- 댓글 삭제 : `Delete  /api/v1/community/comment`

</br>

## 📝 작업 사항
- 댓그 CRUD 진행
- 응답에 따라 상황별 responsedto 생성
- softdelete 이용해서 댓글 삭제 구현
- session에 저장되어 있는 정보를 auth 서버에 담아 요청해서 받은 profileId 값 사용하기

</br>